### PR TITLE
Add band_profile and central_line export, JSON schema, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For an input file `<stem>.oh5`/`<stem>.h5`, the pipeline writes outputs next to 
   - `<stem>_filtered_band_data.csv`
 - An augmented HDF5 copy:
   - `<stem>_modified.h5`
-  - This copy receives computed datasets under `/<scan_name>/EBSD/Data/` (e.g. `Band_Width`, `psnr`, `band_intensity_ratio`, `band_intensity_diff_norm`, `strain`, `stress`, …).
+  - This copy receives computed datasets under `/<scan_name>/EBSD/Data/` (e.g. `Band_Width`, `psnr`, `band_intensity_ratio`, `band_intensity_diff_norm`, `band_profile`, `central_line`, `strain`, `stress`, …).
 - Derived `.ang` files with additional columns:
   - `<stem>_modified_<suffix>.ang`
 
@@ -96,6 +96,9 @@ Notes:
 Derived field definitions:
 - `band_intensity_ratio = I_eff / I_def`
 - `band_intensity_diff_norm = 2*(I_eff - I_def)/(I_eff + I_def)`; values are set to NaN when `I_eff + I_def` is near zero.
+
+JSON annotation details:
+- See [`docs/ebsd_json_schema.md`](docs/ebsd_json_schema.md) for the input/output JSON schemas, `pattern_path` semantics, and mapping to CSV/HDF5 outputs.
 
 ## Optional: CycleGAN / ML preprocessing workflow
 

--- a/docs/ebsd_json_schema.md
+++ b/docs/ebsd_json_schema.md
@@ -1,0 +1,115 @@
+# EBSD JSON Annotation & Output Schemas
+
+This document describes the JSON formats consumed and produced by the Kikuchi Band Analyzer pipeline, including the new optional `pattern_path` input field and the `band_profile` output vector. It also maps JSON fields to CSV columns and HDF5 datasets.
+
+## Input JSON schema (annotations)
+
+Each entry corresponds to a pixel/pattern in the EBSD scan. The pipeline expects a list of entries unless the configuration enables tiling from a single entry.
+
+```json
+[
+  {
+    "x,y": [12, 34],
+    "ind": 1234,
+    "pattern_path": "patterns/pattern_12_34.png",
+    "points": [
+      {
+        "hkl": "1,1,1",
+        "central_line": [25.0, 40.0, 75.0, 40.0],
+        "line_mid_xy": [50.0, 40.0],
+        "line_dist": 3.5,
+        "hkl_group": "111"
+      }
+    ]
+  }
+]
+```
+
+### Required fields
+
+- `points` (list): Annotation list containing band candidates. Each entry must include:
+  - `hkl` (string): Miller indices for the line.
+  - `central_line` (list[float]): `[x1, y1, x2, y2]` endpoints in pixels.
+  - `line_mid_xy` (list[float]): midpoint of the line.
+  - `line_dist` (float): distance from pattern center.
+
+### Optional fields
+
+- `pattern_path` (string): Path to a standalone pattern image or a string like `"(row,col)"` when the pattern is stored inside an OH5/H5 dataset.
+
+### Legacy/deprecated fields
+
+- `x,y` and `ind` are accepted on input but re-derived during processing. They are retained for compatibility with legacy annotation files.
+
+## Output JSON schema (after detection)
+
+After processing, the pipeline adds a `bands` list to each entry. Each band records scalar metrics plus the new `band_profile` vector.
+
+```json
+{
+  "x,y": [12, 34],
+  "ind": 1234,
+  "pattern_path": "patterns/pattern_12_34.png",
+  "points": [...],
+  "bands": [
+    {
+      "hkl": "1,1,1",
+      "hkl_group": "111",
+      "central_line": [25.1, 40.2, 74.8, 40.1],
+      "line_mid_xy": [50.0, 40.0],
+      "line_dist": 3.5,
+      "bandWidth": 12.3,
+      "psnr": 5.4,
+      "band_peak": 200.0,
+      "band_bkg": 40.0,
+      "bandStart": 32,
+      "bandEnd": 58,
+      "centralPeak": 45,
+      "efficientlineIntensity": 41.2,
+      "defficientlineIntensity": 39.8,
+      "band_valid": true,
+      "band_profile": [0.0, 1.2, 3.4, "..."]
+    }
+  ]
+}
+```
+
+### `band_profile` meaning
+
+`band_profile` is the summed intensity profile across the rectangular region centered on the detected band. The profile length is always `rectWidth * 4` samples (as configured in the YAML file). Values are in arbitrary intensity units derived from the source patterns.
+
+## CSV output mapping
+
+The CSV exports include scalar values per detected band:
+
+| JSON field | CSV column |
+| --- | --- |
+| `x,y` | `X,Y` |
+| `ind` | `Ind` |
+| `central_line` | `Central Line` |
+| `line_dist` | `Line Distance` |
+| `bandWidth` | `Band Width` |
+| `band_peak` | `band_peak` |
+| `band_bkg` | `band_bkg` |
+| `psnr` | `psnr` |
+| `efficientlineIntensity` | `efficientlineIntensity` |
+| `defficientlineIntensity` | `defficientlineIntensity` |
+| `band_valid` | `band_valid` |
+
+`band_profile` is not currently exported to CSV because it is a vector.
+
+## HDF5 output mapping
+
+The augmented HDF5 file receives derived datasets under `/<scan_name>/EBSD/Data/`:
+
+| Output dataset | Description |
+| --- | --- |
+| `Band_Width` | Selected band width per pixel (float32). |
+| `psnr` | Selected band PSNR per pixel (float32). |
+| `efficientlineIntensity` | Efficient line intensity per pixel (float32). |
+| `defficientlineIntensity` | Defficient line intensity per pixel (float32). |
+| `band_intensity_ratio` | `I_eff / I_def` per pixel (float32). |
+| `band_profile` | Summed band profile per pixel (float32, shape `n_pixels × (rectWidth*4)`). |
+| `central_line` | Selected band central line per pixel (float32, shape `n_pixels × 4`). |
+
+`band_profile` and `central_line` are populated using the highest-PSNR valid band per pixel. Missing or invalid bands are stored as NaNs.

--- a/tests/test_band_profile_pipeline.py
+++ b/tests/test_band_profile_pipeline.py
@@ -1,0 +1,222 @@
+"""Tests for band profile outputs and JSON handling."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import types
+
+import h5py
+import numpy as np
+
+sys.modules.setdefault("cv2", types.ModuleType("cv2"))
+distutils_module = types.ModuleType("distutils")
+distutils_util = types.ModuleType("distutils.util")
+distutils_util.strtobool = lambda value: value in ("1", "true", "True", True)
+distutils_module.util = distutils_util
+sys.modules.setdefault("distutils", distutils_module)
+sys.modules.setdefault("distutils.util", distutils_util)
+
+import utilities as ut
+from KikuchiBandWidthAutomator import BandWidthAutomator
+from kikuchiBandWidthDetector import prepare_json_input, KikuchiBatchProcessor
+
+
+def _write_min_ang(path: Path, nrows: int, ncols_even: int, column_headers: list[str]) -> None:
+    """
+    Write a minimal .ang file compatible with modify_ang_file.
+
+    Parameters:
+        path: Output file path.
+        nrows: Number of rows in the data section.
+        ncols_even: Number of columns per row.
+        column_headers: Column header names.
+
+    Returns:
+        None.
+    """
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write("# HEADER: Start\n")
+        handle.write("# COLUMN_HEADERS: " + ", ".join(column_headers) + "\n")
+        handle.write(f"# NCOLS_EVEN: {ncols_even}\n")
+        handle.write(f"# NROWS: {nrows}\n")
+        handle.write("# HEADER: End\n")
+        for _ in range(nrows):
+            handle.write("  ".join(["0.00"] * ncols_even) + "\n")
+
+
+def _create_min_h5(path: Path, scan_name: str, n_pixels: int) -> None:
+    """
+    Create a minimal HDF5 file with a CI dataset.
+
+    Parameters:
+        path: Output file path.
+        scan_name: Scan group name.
+        n_pixels: Number of pixels (flattened).
+
+    Returns:
+        None.
+    """
+    with h5py.File(path, "w") as handle:
+        handle.create_dataset("Manufacturer", data="Debug")
+        handle.create_dataset("Version", data="1.0")
+        scan = handle.create_group(scan_name)
+        ebsd = scan.create_group("EBSD")
+        ebsd.create_group("Header")
+        data = ebsd.create_group("Data")
+        data.create_dataset("CI", data=np.zeros(n_pixels, dtype=np.float32))
+
+
+def test_save_results_to_json_includes_band_profile(tmp_path) -> None:
+    """Ensure band_profile is serialized to JSON."""
+    results = [
+        {
+            "x,y": [0, 0],
+            "ind": 0,
+            "bands": [
+                {
+                    "bandWidth": 1.0,
+                    "psnr": 2.0,
+                    "band_profile": np.array([0.1, 0.2, 0.3], dtype=np.float32),
+                    "central_line": [1.0, 2.0, 3.0, 4.0],
+                    "band_valid": True,
+                }
+            ],
+        }
+    ]
+    output_path = tmp_path / "results.json"
+    ut.save_results_to_json(results, path=output_path)
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    band_profile = data[0]["bands"][0]["band_profile"]
+    assert np.allclose(band_profile, [0.1, 0.2, 0.3])
+    assert data[0]["bands"][0]["central_line"] == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_prepare_json_input_handles_optional_pattern_path(tmp_path) -> None:
+    """Support JSON inputs with or without pattern_path."""
+    payload = [
+        {"points": [], "pattern_path": "patterns/pattern_0_0.png"},
+        {"points": []},
+    ]
+    path = tmp_path / "input.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    results = prepare_json_input(str(path), n_patterns=2, tile_from_single=False)
+    assert results[0]["pattern_path"] == "patterns/pattern_0_0.png"
+    assert "pattern_path" not in results[1]
+
+
+def test_batch_processor_preserves_pattern_path(monkeypatch) -> None:
+    """Ensure process_kikuchi_image_at_pixel passes through pattern_path."""
+    ebsd_data = np.zeros((1, 1, 4, 4), dtype=np.float32)
+    config = {
+        "rectWidth": 2,
+        "min_psnr": 1.0,
+        "smoothing_sigma": 1.0,
+        "phase_list": {"name": "Ni", "space_group": 225, "lattice": [1, 1, 1, 90, 90, 90]},
+    }
+
+    def _fake_detect_bands(self):
+        return [
+            {
+                "bandWidth": 1.0,
+                "psnr": 2.0,
+                "band_valid": True,
+                "band_profile": [0.0] * 8,
+                "central_line": [0.0, 1.0, 2.0, 3.0],
+            }
+        ]
+
+    monkeypatch.setattr("kikuchiBandWidthDetector.BandDetector.detect_bands", _fake_detect_bands)
+
+    processor = KikuchiBatchProcessor(
+        ebsd_data=ebsd_data,
+        json_input=[{"points": [], "pattern_path": "(0,0)"}],
+        config=config,
+        desired_hkl="110",
+        phase=None,
+    )
+    entry = processor.process_kikuchi_image_at_pixel(0, 0, processor.json_input[0])
+    assert entry["pattern_path"] == "(0,0)"
+    assert entry["bands"][0]["band_profile"] == [0.0] * 8
+
+
+def test_export_results_writes_band_profile_dataset(tmp_path) -> None:
+    """Write band_profile and central_line datasets to HDF5."""
+    scan_name = "Scan"
+    n_pixels = 2
+    h5_path = tmp_path / "scan.oh5"
+    _create_min_h5(h5_path, scan_name, n_pixels)
+
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "h5_file_path: " + str(h5_path),
+                "desired_hkl_ref_width: 1.0",
+                "elastic_modulus: 1.0",
+                "desired_hkl: 110",
+                "rectWidth: 2",
+                "phase_list:",
+                "  name: Ni",
+                "  space_group: 225",
+                "  lattice: [1, 1, 1, 90, 90, 90]",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    automator = BandWidthAutomator(config_path=str(config_path))
+    automator.modified_data_path = h5_path
+    automator.output_dir = tmp_path
+    automator.base_name = "scan"
+    automator.in_ang_path = tmp_path / "scan.ang"
+    column_headers = [
+        "IQ",
+        "Fit",
+        "110_band_width",
+        "110_eff_deff_ratio",
+        "110_psnr",
+        "110_defficientlineIntensity",
+        "110_efficientlineIntensity",
+        "110_efficientDefficientRatio",
+        "110_Bandwidth_efficientDefficientRatio",
+    ]
+    _write_min_ang(automator.in_ang_path, nrows=1, ncols_even=2, column_headers=column_headers)
+
+    processed = [
+        {
+            "ind": 0,
+            "bands": [
+                {
+                    "band_valid": True,
+                    "psnr": 2.0,
+                    "bandWidth": 1.0,
+                    "efficientlineIntensity": 1.0,
+                    "defficientlineIntensity": 0.5,
+                    "band_profile": [1.0] * 8,
+                    "central_line": [1.0, 2.0, 3.0, 4.0],
+                },
+                {
+                    "band_valid": True,
+                    "psnr": 2.0,
+                    "band_profile": [9.0] * 8,
+                    "central_line": [9.0, 9.0, 9.0, 9.0],
+                },
+            ],
+        },
+        {"ind": 1, "bands": []},
+    ]
+
+    automator.export_results(processed)
+
+    with h5py.File(h5_path, "r") as handle:
+        profile = handle[f"/{scan_name}/EBSD/Data/band_profile"][()]
+        central = handle[f"/{scan_name}/EBSD/Data/central_line"][()]
+
+    assert profile.shape == (n_pixels, 8)
+    assert profile.dtype == np.float32
+    assert np.allclose(profile[0], np.array([1.0] * 8, dtype=np.float32))
+    assert np.isnan(profile[1]).all()
+    assert central.shape == (n_pixels, 4)
+    assert np.allclose(central[0], np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))

--- a/utilities.py
+++ b/utilities.py
@@ -389,6 +389,15 @@ def modify_ang_file(file_path, file_suffix="_band_width", **kwargs):
 
 
 def convert_results(obj):
+    """
+    Recursively convert numpy scalars/arrays into JSON-serializable types.
+
+    Parameters:
+        obj: Object to convert (dict, list, numpy scalar/array, or primitive).
+
+    Returns:
+        JSON-serializable object.
+    """
     if isinstance(obj, dict):
         return {k: convert_results(v) for k, v in obj.items()}
     if isinstance(obj, list):
@@ -401,6 +410,16 @@ def convert_results(obj):
 
 
 def save_results_to_json(results, path="bandOutputData.json"):
+    """
+    Serialize detection results to a JSON file.
+
+    Parameters:
+        results: Results list/dict to serialize.
+        path: Destination JSON path.
+
+    Returns:
+        None.
+    """
     with open(path, "w") as f:
         json.dump(convert_results(results), f, indent=4)
     logging.info("Results saved to %s", path)


### PR DESCRIPTION
### Motivation
- Persist the summed band intensity profile and central line endpoints through detection, JSON output and HDF5 export so vector data are available for downstream analysis. 
- Allow an optional `pattern_path` in input annotations to reference standalone images or `(row,col)` patterns inside OH5/H5 files. 
- Document the new fields and ensure the pipeline remains backwards compatible and robust to malformed inputs.

### Description
- Capture and sanitize the summed intensity profile in `RectangularAreaBandDetector.detect` by introducing `_build_band_profile` and include `band_profile` (list[float]) and `central_line` in the detector output (file: `strategies.py`).
- Propagate `pattern_path` and validate JSON entries in `KikuchiBatchProcessor.process_kikuchi_image_at_pixel` and `prepare_json_input`, adding robust validation and clear errors for malformed JSON (file: `kikuchiBandWidthDetector.py`).
- Convert numpy scalars/arrays to JSON serializable values in `utilities.convert_results` and document `save_results_to_json` so `band_profile` vectors are serialized correctly (file: `utilities.py`).
- In `BandWidthAutomator.export_results`, select the highest-PSNR valid band per pixel, coerce/pad/truncate profiles to a uniform `rectWidth*4` length and write two new HDF5 datasets `/EBSD/Data/band_profile` (shape `n_pixels × profile_length`, dtype `float32`) and `/EBSD/Data/central_line` (shape `n_pixels × 4`, dtype `float32`) with descriptive attributes (file: `KikuchiBandWidthAutomator.py`).
- Add documentation describing input/output JSON schemas and mappings to CSV/HDF5 (`docs/ebsd_json_schema.md`) and update `README.md` to reference the new outputs.
- Add unit tests `tests/test_band_profile_pipeline.py` that mock minimal dependencies for CI and cover JSON serialization, `pattern_path` handling, band profile capture, and HDF5 dataset creation.
- Preserve existing CSV export and scalar metrics; CSV remains unchanged and the earlier scalar workflows are retained.
- Add defensive checks and logging for profile-length consistency, missing fields, non-finite values, and selection ties (PSNR). 

### Testing
- Added unit tests in `tests/test_band_profile_pipeline.py` covering JSON serialization of `band_profile`, optional `pattern_path` handling, pass-through from the batch processor, and HDF5 dataset creation and shapes. 
- Ran: `pytest -q tests/test_band_profile_pipeline.py` which completed successfully: `4 passed` (with unrelated deprecation warnings). 
- Basic runtime checks confirm existing scalar outputs (band width, PSNR, efficient/defficient intensities) are still written to CSV/HDF5 as before.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978999d5e3c8324b1fb2c53489a8e7d)